### PR TITLE
Decrease minimum deployment target to 7.0

### DIFF
--- a/SDForms.podspec
+++ b/SDForms.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/SnowdogApps'
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Rafał Kwiatkowski" => "rafal@snowdog.pl" }
-  s.platform     = :ios, "7.1"
+  s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/SnowdogApps/SDForms.git", :tag => "0.9.3" }
   s.source_files  = "SDForms/**/*.{h,m}"
   s.resource_bundles = {


### PR DESCRIPTION
There is no reason to use 7.1 as deployment target. You can read diffirence between 7.0 and 7.1
https://developer.apple.com/library/ios/releasenotes/General/iOS71APIDiffs/
