### PR TITLE
Update to use bundleForClass (keeps Cocoapods install happy)

### DIFF
--- a/SDForms/Library/FormControllers/SDItemsPickerViewController/SDFormItemsPickerViewController.m
+++ b/SDForms/Library/FormControllers/SDItemsPickerViewController/SDFormItemsPickerViewController.m
@@ -28,8 +28,10 @@ static NSString *kStandardCell = @"StandardCell";
 
 - (id) init
 {
-    NSBundle *bundle = [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"SDFormsResources" withExtension:@"bundle"]];
-    self = [self initWithNibName:@"SDFormItemsPickerViewController" bundle:bundle];
+    NSBundle *bundle = [NSBundle bundleForClass:[SDFormItemsPickerViewController class]];
+    NSURL *bundleURL = [bundle URLForResource:@"SDFormsResources" withExtension:@"bundle"];
+    NSBundle *pickerBundle = [NSBundle bundleWithURL:bundleURL];
+    self = [self initWithNibName:@"SDFormItemsPickerViewController" bundle:pickerBundle];
     if(self) {
         
     }

--- a/SDForms/Library/SDForm.m
+++ b/SDForms/Library/SDForm.m
@@ -38,8 +38,10 @@
         self.tableView.delegate = self;
         self.tableView.dataSource = self;
         
-        NSBundle *bundle = [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"SDFormsResources" withExtension:@"bundle"]];
-        self.toolbar = (SDFormKeyboardToolbar *)[[bundle loadNibNamed:kSDNavigationToolbar owner:[[SDFormKeyboardToolbar alloc] init] options:nil] lastObject];
+        NSBundle *bundle = [NSBundle bundleForClass:[SDForm class]];
+        NSURL *bundleURL = [bundle URLForResource:@"SDFormsResources" withExtension:@"bundle"];
+        NSBundle *formBundle = [NSBundle bundleWithURL:bundleURL];
+        self.toolbar = (SDFormKeyboardToolbar *)[[formBundle loadNibNamed:kSDNavigationToolbar owner:[[SDFormKeyboardToolbar alloc] init] options:nil] lastObject];
         [self.toolbar setToolbarDelegate:self];
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];

--- a/SDForms/Library/SDFormField.m
+++ b/SDForms/Library/SDFormField.m
@@ -217,8 +217,10 @@
 }
 
 - (NSBundle *)defaultBundle {
-    NSBundle *bundle = [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"SDFormsResources" withExtension:@"bundle"]];
-    return bundle;
+    NSBundle *bundle = [NSBundle bundleForClass:[SDFormField class]];
+    NSURL *bundleURL = [bundle URLForResource:@"SDFormsResources" withExtension:@"bundle"];
+    NSBundle *formFieldBundle = [NSBundle bundleWithURL:bundleURL];
+    return formFieldBundle;
 }
 
 @end


### PR DESCRIPTION
Bundle loader fails in the case of a swift + cocopods + dynamic frameworks in Podfile.
